### PR TITLE
Update pyo3 to 0.22.0 (without "py-clone")

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,3 @@ all-features = true
 
 [features]
 gil-refs = ["pyo3/gil-refs"]
-py-clone = ["pyo3/py-clone"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-complex = ">= 0.2, < 0.5"
 num-integer = "0.1"
 num-traits = "0.2"
 ndarray = ">= 0.13, < 0.16"
-pyo3 = { version = "0.22.0", default-features = false, features = ["macros", "py-clone"] }
+pyo3 = { version = "0.22.0", default-features = false, features = ["macros"] }
 rustc-hash = "1.1"
 
 [dev-dependencies]
@@ -34,3 +34,4 @@ all-features = true
 
 [features]
 gil-refs = ["pyo3/gil-refs"]
+py-clone = ["pyo3/py-clone"]

--- a/src/array.rs
+++ b/src/array.rs
@@ -926,6 +926,7 @@ impl<T: Element, D: Dimension> PyArray<T, D> {
 }
 
 #[cfg(feature = "nalgebra")]
+#[cfg(feature = "gil-refs")]
 impl<N, D> PyArray<N, D>
 where
     N: nalgebra::Scalar + Element,

--- a/src/array.rs
+++ b/src/array.rs
@@ -1069,7 +1069,7 @@ impl<T: Element> PyArray<T, Ix1> {
         unsafe {
             let array = PyArray::new_bound(py, [slice.len()], false);
             let mut data_ptr = array.data();
-            clone_elements(slice, &mut data_ptr);
+            clone_elements(py, slice, &mut data_ptr);
             array
         }
     }
@@ -1183,7 +1183,7 @@ impl<T: Element> PyArray<T, Ix2> {
                     cold();
                     return Err(FromVecError::new(v.len(), len2));
                 }
-                clone_elements(v, &mut data_ptr);
+                clone_elements(py, v, &mut data_ptr);
             }
             Ok(array)
         }
@@ -1248,7 +1248,7 @@ impl<T: Element> PyArray<T, Ix3> {
                         cold();
                         return Err(FromVecError::new(v.len(), len3));
                     }
-                    clone_elements(v, &mut data_ptr);
+                    clone_elements(py, v, &mut data_ptr);
                 }
             }
             Ok(array)
@@ -1469,13 +1469,13 @@ impl<T: Element + AsPrimitive<f64>> PyArray<T, Ix1> {
     }
 }
 
-unsafe fn clone_elements<T: Element>(elems: &[T], data_ptr: &mut *mut T) {
+unsafe fn clone_elements<T: Element>(py: Python<'_>, elems: &[T], data_ptr: &mut *mut T) {
     if T::IS_COPY {
         ptr::copy_nonoverlapping(elems.as_ptr(), *data_ptr, elems.len());
         *data_ptr = data_ptr.add(elems.len());
     } else {
         for elem in elems {
-            data_ptr.write(elem.clone());
+            data_ptr.write(elem.py_clone(py));
             *data_ptr = data_ptr.add(1);
         }
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -242,7 +242,7 @@ impl<T, D> PyArray<T, D> {
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_owned_ptr_or_opt`] and inherits its safety contract.
     pub unsafe fn from_owned_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
-        #[allow(deprecated)]
+        #![allow(deprecated)]
         py.from_owned_ptr(ptr)
     }
 
@@ -252,7 +252,7 @@ impl<T, D> PyArray<T, D> {
     ///
     /// This is a wrapper around [`pyo3::FromPyPointer::from_borrowed_ptr_or_opt`] and inherits its safety contract.
     pub unsafe fn from_borrowed_ptr<'py>(py: Python<'py>, ptr: *mut ffi::PyObject) -> &'py Self {
-        #[allow(deprecated)]
+        #![allow(deprecated)]
         py.from_borrowed_ptr(ptr)
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -2274,7 +2274,7 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
         as_view(self, |shape, ptr| unsafe {
             RawArrayViewMut::from_shape_ptr(shape, ptr)
         })
-    }    
+    }
 
     fn to_owned_array(&self) -> Array<T, D>
     where

--- a/src/array.rs
+++ b/src/array.rs
@@ -1689,10 +1689,7 @@ pub trait PyArrayMethods<'py, T, D>: PyUntypedArrayMethods<'py> {
     where
         T: Element,
         D: Dimension,
-        Idx: NpyIndex<Dim = D>,
-    {
-        unsafe { self.get(index) }.cloned()
-    }
+        Idx: NpyIndex<Dim = D>;
 
     /// Turn an array with fixed dimensionality into one with dynamic dimensionality.
     fn to_dyn(&self) -> &Bound<'py, PyArray<T, IxDyn>>
@@ -1723,10 +1720,7 @@ pub trait PyArrayMethods<'py, T, D>: PyUntypedArrayMethods<'py> {
     fn to_vec(&self) -> Result<Vec<T>, NotContiguousError>
     where
         T: Element,
-        D: Dimension,
-    {
-        unsafe { self.as_slice() }.map(ToOwned::to_owned)
-    }
+        D: Dimension;
 
     /// Get an immutable borrow of the NumPy array
     fn try_readonly(&self) -> Result<PyReadonlyArray<'py, T, D>, BorrowError>
@@ -1830,10 +1824,7 @@ pub trait PyArrayMethods<'py, T, D>: PyUntypedArrayMethods<'py> {
     fn to_owned_array(&self) -> Array<T, D>
     where
         T: Element,
-        D: Dimension,
-    {
-        unsafe { self.as_array() }.to_owned()
-    }
+        D: Dimension;
 
     /// Copies `self` into `other`, performing a data type conversion if necessary.
     ///
@@ -2209,8 +2200,27 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
         Some(&mut *ptr)
     }
 
+    fn get_owned<Idx>(&self, index: Idx) -> Option<T>
+    where
+        T: Element,
+        D: Dimension,
+        Idx: NpyIndex<Dim = D>,
+    {
+        let element = unsafe { self.get(index) };
+        element.map(|elem| elem.py_clone(self.py()))
+    }
+
     fn to_dyn(&self) -> &Bound<'py, PyArray<T, IxDyn>> {
         unsafe { self.downcast_unchecked() }
+    }
+
+    fn to_vec(&self) -> Result<Vec<T>, NotContiguousError>
+    where
+        T: Element,
+        D: Dimension,
+    {
+        let slice = unsafe { self.as_slice() };
+        slice.map(|slc| T::vec_from_slice(self.py(), slc))
     }
 
     fn try_readonly(&self) -> Result<PyReadonlyArray<'py, T, D>, BorrowError>
@@ -2263,6 +2273,15 @@ impl<'py, T, D> PyArrayMethods<'py, T, D> for Bound<'py, PyArray<T, D>> {
         as_view(self, |shape, ptr| unsafe {
             RawArrayViewMut::from_shape_ptr(shape, ptr)
         })
+    }    
+
+    fn to_owned_array(&self) -> Array<T, D>
+    where
+        T: Element,
+        D: Dimension,
+    {
+        let view = unsafe { self.as_array() };
+        T::array_from_view(self.py(), view)
     }
 
     fn copy_to<U: Element>(&self, other: &Bound<'py, PyArray<U, D>>) -> PyResult<()>

--- a/src/borrow/mod.rs
+++ b/src/borrow/mod.rs
@@ -305,7 +305,7 @@ where
     /// }
     ///
     /// Python::with_gil(|py| {
-    ///     let np = py.eval("__import__('numpy')", None, None).unwrap();
+    ///     let np = py.eval_bound("__import__('numpy')", None, None).unwrap();
     ///     let sum_standard_layout = wrap_pyfunction!(sum_standard_layout)(py).unwrap();
     ///     let sum_dynamic_strides = wrap_pyfunction!(sum_dynamic_strides)(py).unwrap();
     ///

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -195,7 +195,7 @@ where
                     let array = PyArray::<A, _>::new_bound(py, dim, false);
                     let mut data_ptr = array.data();
                     for item in self.iter() {
-                        data_ptr.write(item.clone());
+                        data_ptr.write(item.py_clone(py));
                         data_ptr = data_ptr.add(1);
                     }
                     array
@@ -228,7 +228,7 @@ where
                 ptr::copy_nonoverlapping(self.data.ptr(), data_ptr, self.len());
             } else {
                 for item in self.iter() {
-                    data_ptr.write(item.clone());
+                    data_ptr.write(item.py_clone(py));
                     data_ptr = data_ptr.add(1);
                 }
             }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 use pyo3::{sync::GILProtected, Bound, Py, Python};
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, impl_py_clone};
+use crate::dtype::{impl_py_clone, Element, PyArrayDescr, PyArrayDescrMethods};
 use crate::npyffi::{PyArray_DatetimeDTypeMetaData, NPY_DATETIMEUNIT, NPY_TYPES};
 
 /// Represents the [datetime units][datetime-units] supported by NumPy

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -66,7 +66,7 @@ use std::marker::PhantomData;
 use pyo3::{sync::GILProtected, Bound, Py, Python};
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods};
+use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, impl_py_clone};
 use crate::npyffi::{PyArray_DatetimeDTypeMetaData, NPY_DATETIMEUNIT, NPY_TYPES};
 
 /// Represents the [datetime units][datetime-units] supported by NumPy
@@ -153,6 +153,8 @@ impl<U: Unit> From<Datetime<U>> for i64 {
     }
 }
 
+impl_py_clone!(Datetime<U>; [U: Unit]);
+
 unsafe impl<U: Unit> Element for Datetime<U> {
     const IS_COPY: bool = true;
 
@@ -187,6 +189,8 @@ impl<U: Unit> From<Timedelta<U>> for i64 {
         val.0
     }
 }
+
+impl_py_clone!(Timedelta<U>; [U: Unit]);
 
 unsafe impl<U: Unit> Element for Timedelta<U> {
     const IS_COPY: bool = true;

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -3,7 +3,6 @@ use std::os::raw::{
     c_char, c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort,
 };
 use std::ptr;
-use ndarray::{Array, ArrayView, Dimension};
 
 #[cfg(feature = "half")]
 use half::{bf16, f16};
@@ -625,54 +624,55 @@ impl<'py> PyArrayDescrMethods<'py> for Bound<'py, PyArrayDescr> {
 
 impl Sealed for Bound<'_, PyArrayDescr> {}
 
-
 /// Weaker form of `Clone` for types that can be cloned while the GIL is held.
-/// 
-/// Any type that implements `Clone` can trivially implement `PyClone` by forwarding 
-/// to the `Clone::clone` method. However, some types (notably `PyObject`) can only 
+///
+/// Any type that implements `Clone` can trivially implement `PyClone` by forwarding
+/// to the `Clone::clone` method. However, some types (notably `PyObject`) can only
 /// be safely cloned while the GIL is held, and therefore cannot implement `Clone`.
 /// This trait provides a mechanism for performing a clone while the GIL is held, as
 /// represented by the [`Python`] token provided as an argument to the [`py_clone`]
-/// method. All API's in the `numpy` crate require the GIL to be held, so this weaker 
+/// method. All API's in the `numpy` crate require the GIL to be held, so this weaker
 /// alternative to `Clone` is a sufficient prerequisite for implementing the
 /// [`Element`] trait.
-/// 
+///
 /// # Implementing `PyClone`
 /// Implementing this trait is trivial for most types, and simply requires defining
-/// the `py_clone` method. The `vec_from_slice` and `array_from_view` methods have 
-/// default implementations that simply map the `py_clone` method to each item in 
+/// the `py_clone` method. The `vec_from_slice` and `array_from_view` methods have
+/// default implementations that simply map the `py_clone` method to each item in
 /// the collection, but types may want to override these implementations if there
-/// is a more efficient way to perform the conversion. In particular, `Clone` types 
-/// may instead defer to the `ToOwned::to_owned` and `ArrayBase::to_owned` methods 
+/// is a more efficient way to perform the conversion. In particular, `Clone` types
+/// may instead defer to the `ToOwned::to_owned` and `ArrayBase::to_owned` methods
 /// for increased performance.
-/// 
+///
 /// [`py_clone`]: Self::py_clone
 pub trait PyClone: Sized {
     /// Create a clone of the value while the GIL is guaranteed to be held.
     fn py_clone(&self, py: Python<'_>) -> Self;
-    
+
     /// Create an owned copy of the slice while the GIL is guaranteed to be held.
-    /// 
-    /// Some types may provide implementations of this method that are more efficient 
+    ///
+    /// Some types may provide implementations of this method that are more efficient
     /// than simply mapping the `py_clone` method to each element in the slice.
     #[inline]
     fn vec_from_slice(py: Python<'_>, slc: &[Self]) -> Vec<Self> {
         slc.iter().map(|elem| elem.py_clone(py)).collect()
     }
-    
+
     /// Create an owned copy of the array while the GIL is guaranteed to be held.
-    /// 
-    /// Some types may provide implementations of this method that are more efficient 
+    ///
+    /// Some types may provide implementations of this method that are more efficient
     /// than simply mapping the `py_clone` method to each element in the view.
     #[inline]
-    fn array_from_view<D>(py: Python<'_>, view: ArrayView<'_, Self, D>) -> Array<Self, D> 
+    fn array_from_view<D>(
+        py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>,
+    ) -> ::ndarray::Array<Self, D>
     where
-        D: Dimension
+        D: ::ndarray::Dimension,
     {
         view.map(|elem| elem.py_clone(py))
     }
 }
-
 
 /// Represents that a type can be an element of `PyArray`.
 ///
@@ -784,17 +784,17 @@ macro_rules! impl_py_clone {
             fn py_clone(&self, _py: ::pyo3::Python<'_>) -> Self {
                 self.clone()
             }
-            
+
             #[inline]
             fn vec_from_slice(_py: ::pyo3::Python<'_>, slc: &[Self]) -> Vec<Self> {
                 slc.to_owned()
             }
-            
+
             #[inline]
             fn array_from_view<D>(
-                _py: ::pyo3::Python<'_>, 
+                _py: ::pyo3::Python<'_>,
                 view: ::ndarray::ArrayView<'_, Self, D>
-            ) -> ::ndarray::Array<Self, D> 
+            ) -> ::ndarray::Array<Self, D>
             where
                 D: ::ndarray::Dimension
             {
@@ -910,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_dtype_names() {
-        fn type_name<T: Element>(py: Python) -> Bound<PyString> {
+        fn type_name<T: Element>(py: Python<'_>) -> Bound<'_, PyString> {
             dtype_bound::<T>(py).typeobj().qualname().unwrap()
         }
         Python::with_gil(|py| {

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -3,6 +3,7 @@ use std::os::raw::{
     c_char, c_int, c_long, c_longlong, c_short, c_uint, c_ulong, c_ulonglong, c_ushort,
 };
 use std::ptr;
+use ndarray::{Array, ArrayView, Dimension};
 
 #[cfg(feature = "half")]
 use half::{bf16, f16};
@@ -623,6 +624,55 @@ impl<'py> PyArrayDescrMethods<'py> for Bound<'py, PyArrayDescr> {
 }
 
 impl Sealed for Bound<'_, PyArrayDescr> {}
+
+
+/// Weaker form of `Clone` for types that can be cloned while the GIL is held.
+/// 
+/// Any type that implements `Clone` can trivially implement `PyClone` by forwarding 
+/// to the `Clone::clone` method. However, some types (notably `PyObject`) can only 
+/// be safely cloned while the GIL is held, and therefore cannot implement `Clone`.
+/// This trait provides a mechanism for performing a clone while the GIL is held, as
+/// represented by the [`Python`] token provided as an argument to the [`py_clone`]
+/// method. All API's in the `numpy` crate require the GIL to be held, so this weaker 
+/// alternative to `Clone` is a sufficient prerequisite for implementing the
+/// [`Element`] trait.
+/// 
+/// # Implementing `PyClone`
+/// Implementing this trait is trivial for most types, and simply requires defining
+/// the `py_clone` method. The `vec_from_slice` and `array_from_view` methods have 
+/// default implementations that simply map the `py_clone` method to each item in 
+/// the collection, but types may want to override these implementations if there
+/// is a more efficient way to perform the conversion. In particular, `Clone` types 
+/// may instead defer to the `ToOwned::to_owned` and `ArrayBase::to_owned` methods 
+/// for increased performance.
+/// 
+/// [`py_clone`]: Self::py_clone
+pub trait PyClone: Sized {
+    /// Create a clone of the value while the GIL is guaranteed to be held.
+    fn py_clone(&self, py: Python<'_>) -> Self;
+    
+    /// Create an owned copy of the slice while the GIL is guaranteed to be held.
+    /// 
+    /// Some types may provide implementations of this method that are more efficient 
+    /// than simply mapping the `py_clone` method to each element in the slice.
+    #[inline]
+    fn vec_from_slice(py: Python<'_>, slc: &[Self]) -> Vec<Self> {
+        slc.iter().map(|elem| elem.py_clone(py)).collect()
+    }
+    
+    /// Create an owned copy of the array while the GIL is guaranteed to be held.
+    /// 
+    /// Some types may provide implementations of this method that are more efficient 
+    /// than simply mapping the `py_clone` method to each element in the view.
+    #[inline]
+    fn array_from_view<D>(py: Python<'_>, view: ArrayView<'_, Self, D>) -> Array<Self, D> 
+    where
+        D: Dimension
+    {
+        view.map(|elem| elem.py_clone(py))
+    }
+}
+
 
 /// Represents that a type can be an element of `PyArray`.
 ///

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -711,7 +711,7 @@ pub trait PyClone: Sized {
 ///
 /// [enumerated-types]: https://numpy.org/doc/stable/reference/c-api/dtype.html#enumerated-types
 /// [data-models]: https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
-pub unsafe trait Element: Clone + Send {
+pub unsafe trait Element: PyClone + Send {
     /// Flag that indicates whether this type is trivially copyable.
     ///
     /// It should be set to true for all trivially copyable types (like scalar types

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -863,6 +863,13 @@ impl_element_scalar!(Complex64 => NPY_CDOUBLE,
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl_element_scalar!(usize, isize);
 
+impl PyClone for PyObject {
+    #[inline]
+    fn py_clone(&self, py: Python<'_>) -> Self {
+        self.clone_ref(py)
+    }
+}
+
 unsafe impl Element for PyObject {
     const IS_COPY: bool = false;
 

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -847,7 +847,7 @@ unsafe impl Element for bf16 {
             .get_or_init(py, || {
                 PyArrayDescr::new_bound(py, "bfloat16").expect("A package which provides a `bfloat16` data type for NumPy is required to use the `half::bf16` element type.").unbind()
             })
-            .clone()
+            .clone_ref(py)
             .into_bound(py)
     }
 }

--- a/src/dtype.rs
+++ b/src/dtype.rs
@@ -776,6 +776,35 @@ fn npy_int_type<T: Bounded + Zero + Sized + PartialEq>() -> NPY_TYPES {
     }
 }
 
+// Implements `PyClone` for a type that implements `Clone`
+macro_rules! impl_py_clone {
+    ($ty:ty $(; [$param:ident $(: $bound:ident)?])?) => {
+        impl <$($param$(: $bound)*)?> $crate::dtype::PyClone for $ty {
+            #[inline]
+            fn py_clone(&self, _py: ::pyo3::Python<'_>) -> Self {
+                self.clone()
+            }
+            
+            #[inline]
+            fn vec_from_slice(_py: ::pyo3::Python<'_>, slc: &[Self]) -> Vec<Self> {
+                slc.to_owned()
+            }
+            
+            #[inline]
+            fn array_from_view<D>(
+                _py: ::pyo3::Python<'_>, 
+                view: ::ndarray::ArrayView<'_, Self, D>
+            ) -> ::ndarray::Array<Self, D> 
+            where
+                D: ::ndarray::Dimension
+            {
+                view.to_owned()
+            }
+        }
+    }
+}
+pub(crate) use impl_py_clone;
+
 macro_rules! impl_element_scalar {
     (@impl: $ty:ty, $npy_type:expr $(,#[$meta:meta])*) => {
         $(#[$meta])*
@@ -786,6 +815,7 @@ macro_rules! impl_element_scalar {
                 PyArrayDescr::from_npy_type(py, $npy_type)
             }
         }
+        impl_py_clone!($ty);
     };
     ($ty:ty => $npy_type:ident $(,#[$meta:meta])*) => {
         impl_element_scalar!(@impl: $ty, NPY_TYPES::$npy_type $(,#[$meta])*);
@@ -821,6 +851,9 @@ unsafe impl Element for bf16 {
             .into_bound(py)
     }
 }
+
+#[cfg(feature = "half")]
+impl_py_clone!(bf16);
 
 impl_element_scalar!(Complex32 => NPY_CFLOAT,
     #[doc = "Complex type with `f32` components which maps to `numpy.csingle` (`numpy.complex64`)."]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use crate::convert::{IntoPyArray, NpyIndex, ToNpyDims, ToPyArray};
 #[cfg(feature = "gil-refs")]
 pub use crate::dtype::dtype;
 pub use crate::dtype::{
-    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods,
+    dtype_bound, Complex32, Complex64, Element, PyArrayDescr, PyArrayDescrMethods, PyClone,
 };
 pub use crate::error::{BorrowError, FromVecError, NotContiguousError};
 pub use crate::npyffi::{PY_ARRAY_API, PY_UFUNC_API};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 #![cfg_attr(not(feature = "nalgebra"), doc = "```rust,ignore")]
 //! use numpy::pyo3::Python;
 //! use numpy::nalgebra::Matrix3;
-//! use numpy::{pyarray, ToPyArray};
+//! use numpy::{pyarray_bound, ToPyArray, PyArrayMethods};
 //!
 //! Python::with_gil(|py| {
-//!     let py_array = pyarray![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
+//!     let py_array = pyarray_bound![py, [0, 1, 2], [3, 4, 5], [6, 7, 8]];
 //!
 //!     let py_array_square;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //!         Matrix3::new(30, 36, 42, 66, 81, 96, 102, 126, 150)
 //!     );
 //! });
-//! ```
+#![doc = "```"]
 //!
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,11 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //!
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
-
-#![deny(missing_docs, missing_debug_implementations)]
+#![deny(missing_docs)]
+// requiring `Debug` impls is not relevant without gil-refs since `&PyArray` and 
+// similar aren't constructible and the `pyo3::pyobject_native_type_base` macro 
+// does not provide a `Debug` impl
+#![cfg_attr(feature = "gil-refs", deny(missing_debug_implementations))]
 
 pub mod array;
 mod array_like;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,8 @@ as well as the [`PyReadonlyArray::try_as_matrix`] and [`PyReadwriteArray::try_as
 //! [c-api]: https://numpy.org/doc/stable/reference/c-api
 //! [ndarray]: https://numpy.org/doc/stable/reference/arrays.ndarray.html
 #![deny(missing_docs)]
-// requiring `Debug` impls is not relevant without gil-refs since `&PyArray` and 
-// similar aren't constructible and the `pyo3::pyobject_native_type_base` macro 
-// does not provide a `Debug` impl
+// requiring `Debug` impls is not relevant without gil-refs since `&PyArray`
+// and similar aren't constructible
 #![cfg_attr(feature = "gil-refs", deny(missing_debug_implementations))]
 
 pub mod array;

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -86,7 +86,7 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
 impl<const N: usize> PyClone for PyFixedString<N> {
     #[inline]
     fn py_clone(&self, _py: Python<'_>) -> Self {
-        self.clone()
+        *self
     }
 
     #[inline]
@@ -96,11 +96,11 @@ impl<const N: usize> PyClone for PyFixedString<N> {
 
     #[inline]
     fn array_from_view<D>(
-        _py: Python<'_>, 
-        view: ::ndarray::ArrayView<'_, Self, D>
-    ) -> ::ndarray::Array<Self, D> 
+        _py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>,
+    ) -> ::ndarray::Array<Self, D>
     where
-        D: ::ndarray::Dimension
+        D: ::ndarray::Dimension,
     {
         view.to_owned()
     }
@@ -170,7 +170,7 @@ impl<const N: usize> From<[Py_UCS4; N]> for PyFixedUnicode<N> {
 impl<const N: usize> PyClone for PyFixedUnicode<N> {
     #[inline]
     fn py_clone(&self, _py: Python<'_>) -> Self {
-        self.clone()
+        *self
     }
 
     #[inline]
@@ -180,11 +180,11 @@ impl<const N: usize> PyClone for PyFixedUnicode<N> {
 
     #[inline]
     fn array_from_view<D>(
-        _py: Python<'_>, 
-        view: ::ndarray::ArrayView<'_, Self, D>
-    ) -> ::ndarray::Array<Self, D> 
+        _py: Python<'_>,
+        view: ::ndarray::ArrayView<'_, Self, D>,
+    ) -> ::ndarray::Array<Self, D>
     where
-        D: ::ndarray::Dimension
+        D: ::ndarray::Dimension,
     {
         view.to_owned()
     }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -17,7 +17,7 @@ use pyo3::{
 };
 use rustc_hash::FxHashMap;
 
-use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods};
+use crate::dtype::{Element, PyArrayDescr, PyArrayDescrMethods, PyClone};
 use crate::npyffi::NPY_TYPES;
 
 /// A newtype wrapper around [`[u8; N]`][Py_UCS1] to handle [`byte` scalars][numpy-bytes] while satisfying coherence.
@@ -83,6 +83,29 @@ unsafe impl<const N: usize> Element for PyFixedString<N> {
     }
 }
 
+impl<const N: usize> PyClone for PyFixedString<N> {
+    #[inline]
+    fn py_clone(&self, _py: Python<'_>) -> Self {
+        self.clone()
+    }
+
+    #[inline]
+    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
+        slc.to_owned()
+    }
+
+    #[inline]
+    fn array_from_view<D>(
+        _py: Python<'_>, 
+        view: ::ndarray::ArrayView<'_, Self, D>
+    ) -> ::ndarray::Array<Self, D> 
+    where
+        D: ::ndarray::Dimension
+    {
+        view.to_owned()
+    }
+}
+
 /// A newtype wrapper around [`[PyUCS4; N]`][Py_UCS4] to handle [`str_` scalars][numpy-str] while satisfying coherence.
 ///
 /// Note that when creating arrays of Unicode strings without an explicit `dtype`,
@@ -141,6 +164,29 @@ impl<const N: usize> fmt::Display for PyFixedUnicode<N> {
 impl<const N: usize> From<[Py_UCS4; N]> for PyFixedUnicode<N> {
     fn from(val: [Py_UCS4; N]) -> Self {
         Self(val)
+    }
+}
+
+impl<const N: usize> PyClone for PyFixedUnicode<N> {
+    #[inline]
+    fn py_clone(&self, _py: Python<'_>) -> Self {
+        self.clone()
+    }
+
+    #[inline]
+    fn vec_from_slice(_py: Python<'_>, slc: &[Self]) -> Vec<Self> {
+        slc.to_owned()
+    }
+
+    #[inline]
+    fn array_from_view<D>(
+        _py: Python<'_>, 
+        view: ::ndarray::ArrayView<'_, Self, D>
+    ) -> ::ndarray::Array<Self, D> 
+    where
+        D: ::ndarray::Dimension
+    {
+        view.to_owned()
     }
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -6,13 +6,15 @@ use ndarray::{array, s, Array1, Dim};
 use numpy::prelude::*;
 use numpy::{
     dtype_bound, get_array_module, npyffi::NPY_ORDER, pyarray_bound, PyArray, PyArray1, PyArray2,
-    PyArrayDescr, PyArrayDyn, PyFixedString, PyFixedUnicode,
+    PyArrayDescr, PyFixedString, PyFixedUnicode,
 };
 use pyo3::{
     py_run, pyclass, pymethods,
     types::{IntoPyDict, PyAnyMethods, PyDict, PyList},
-    Bound, Py, PyResult, Python,
+    Bound, Py, Python,
 };
+#[cfg(feature = "gil-refs")]
+use {numpy::PyArrayDyn, pyo3::PyResult};
 
 fn get_np_locals(py: Python<'_>) -> Bound<'_, PyDict> {
     [("np", get_array_module(py).unwrap())].into_py_dict_bound(py)


### PR DESCRIPTION
This PR builds on #431 to migrate to PyO3 0.22.0 without needing to activate the problematic `py-clone` feature.

## Background
PyO3 recently released version 0.22.0 which includes [many new features](https://pyo3.rs/v0.22.0/changelog), but also includes the next step in deprecating the _gil-refs_ API by putting it behind the opt-in `gil-refs` feature flag. @bschoenmaeckers's PR went long way towards updating `numpy` for the migration by mirroring the gil-refs deprecation and feature-gating the methods that depend on it, but @juntyr raised the valid concerns about its unconditional activation of  PyO3's `py-clone` feature flag.

## The problem with `py-clone`
The PyO3 0.22.0 release includes [PyO3#4095](https://github.com/PyO3/pyo3/pull/4095)'s removal of the ability to clone `Py<T>` while the GIL is not held, which was implemented by removing its `Clone` impl and requiring users  to either convert to `Bound<T>` before cloning or call the `clone_ref` method instead. The opt-in `py-clone` feature flag was added that restores the `Clone` implementation, but a panic is triggered if a clone is attempted while the GIL is not held. Enabling this feature may be convenient and fairly harmless in some use cases but can be hugely problematic in others, and we should not unconditionally impose  the risk of panicking clones on all `numpy` users.

#### Why not just add our own `py-clone` feature?
This was suggested in #431, but has a major problem related to the `Element` impl for `PyObject` (aka `Py<PyAny>`). The problem is that `Clone` is a supertrait of `Element`, so `PyObject` losing its `Clone` impl when the `py-clone` feature is disabled means its `Element` impl must be disabled as well. So if we made the feature _opt-in_ as was done by PyO3, then by default we would lose all support for object arrays which would be a huge regression. Making the feature _opt-out_ instead is also a bad option, so we need another way.

#### Could we implement `Element` for `Bound<PyAny>` instead?
No. Unfortunately `Bound<T>` does not (and can not) implement `Send`, which is another requirement for implementing `Element`. So retaining the `Element` impl for `Py<T>` is our only option for supporting object arrays without major reworks.

## Eliminating our dependence on `py-clone`
The sad thing about this issue is that it really shouldn't be a problem in the context of `numpy` -- all of our API's require the GIL anyways, so it should always be safe to clone the `PyObjects` in our arrays. But that that doesn't help the fact that we still need a way to `clone` elements (and `to_owned` slices and array views), and we were relying on the `Element` trait's `Clone` requirement to do so. This PR solves the dilemma by replacing the `Clone` supertrait with a new trait `PyClone`, which can be safely implemented for `PyObject` and all existing `Element` impls.

#### The new `PyClone` trait
The new `PyClone` trait is a weaker form of the standard `Clone` trait that represents types which can be cloned while the GIL is held. Philosophically (though not in practice), this includes all `Clone` types that don't care about the GIL, as well as types like `Py<T>` that can only be cloned when it is held.

 The trait has the following (simplified) definition:
```rust
pub trait PyClone: Sized {
    /// Create a clone of the value while the GIL is guaranteed to be held.
    fn py_clone(&self, py: Python<'_>) -> Self;
}
```
Any type that implements `Clone` can trivially implement `PyClone` by ignoring the `py` argument and simply delegating to its `clone` method. Meanwhile, `PyObject` can implement this trait by using the provided `Python` token to call `Py::clone_ref`. The actualy trait also defines a couple of methods (not shown above) for cloning collections, which have default implementations that types can override if there is a more efficient way to do so then simply mapping the `py_clone` method to each item.

Adding a trait like this to PyO3 was discussed in [PyO3#4133](https://github.com/PyO3/pyo3/issues/4133), but it is not clear if/when this would be implemented. If such a trait ends up getting added to PyO3 we can later transition to using it, but I don't think we should hold up `numpy`'s migration to 0.22.0 waiting for that to happen. 

#### Drawbacks
Ideally we would provide a blanket impl of `PyClone` for all `T: Clone` and then a specific impl for `PyObject`, which would let us avoid the breaking change for anyone with custom `Element` impls that will now need to add a `PyClone` impl as well. Unfortunately, this is not allowed due to possible impl overlaps since the compiler asserts that PyO3 restoring the `Clone` impl for `Py<T>` should not be a breaking change. If `PyClone` trait was instead defined in the `pyo3` crate then they _could_ provide these impls, but it is unlikely that they _would_ (as discussed in [PyO3#4133](https://github.com/PyO3/pyo3/issues/4133)) since it would prevent them defining necessary generic impls like `Option<T: PyClone>`.

So, this will inevitably need to be a breaking change for downstream crates defining custom `Element` impls for their types. Luckily it extremely rare for crates to do this, and adding the `PyClone` impl is absolutely trivial in comparison to all the other changes needed to migrate away from the gil-refs API in the PyO3 0.21/0.22 updates anyways.

#### Patching `numpy` internals
As mentioned before, all of the `numpy` API's already require access to a `Python` token to prove that the GIL is held, so most of the necessary updates simply require replacing `item.clone()` calls with `item.py_clone(py)`.   The only exceptions are the calls to `<[T] as ToOwned>::to_owned` and `ArrayView::to_owned` (both of which require `T: Clone`), which now delegate to `PyClone`'s provided methods discussed above. Delegating to these collection-specific methods is used instead of simply mapping the `py_clone` method to avoid losing out on the optimized `to_owned` implementations for `Clone` types.

## Tasks
- [x] Deprecate the `gil-refs` API
  - [x] Add `gil-refs` feature guarding all usages of PyO3's gil-refs API (completed by @bschoenmaeckers)
  - [x] Update doctests and examples to use the bound API instead of gil-refs
- [x] Eliminate `py-clone` feature dependency 
  - [x] Add `PyClone` trait to replace `Clone` as a supertrait of `Element`
  - [x] Add `PyClone` impls for all internal `Element` types
  - [x] Update `numpy` internals to use `PyClone` instead of `Clone`
- [ ] Documentation
  - [x] Document the `PyClone` trait
  - [ ] Update the `Element` docs to reference the newly required supertrait
  - [ ] Create changelog and/or migration guide 
- [ ] Add tests -- the existing tests cover the changes pretty well, but there may be `PyClone`-specific tests worth adding.